### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Huploadify
 
 jQuery文件上传插件，HTML5版uploadify，保持与uploadify一致的API，完全山寨。Uploadify官网：[http://www.uploadify.com/](http://www.uploadify.com/)
 
-#####已实现的特性有：
+##### 已实现的特性有：
 1. 多文件上传
 2. 显示进度条
 3. 显示已上传文件大小和百分比
@@ -15,7 +15,7 @@ jQuery文件上传插件，HTML5版uploadify，保持与uploadify一致的API，
 
 ------------
 
-#####已实现常用的API，default配置信息如下：
+##### 已实现常用的API，default配置信息如下：
     fileTypeExts:'*.*',//允许上传的文件类型，格式'*.jpg;*.doc'
     uploader:'',//文件提交的地址
     auto:false,//是否开启自动上传
@@ -39,7 +39,7 @@ jQuery文件上传插件，HTML5版uploadify，保持与uploadify一致的API，
     onDestroy:null,//在调用destroy方法时触发
     onSelect:null,//选择文件后的回调函数，可传入参数file
     onQueueComplete:null//队列中的所有文件上传完成后触发
-#####使用方法
+##### 使用方法
 首先页面上需要一个容器，通常是一个div，如：
 
 `<div id="upload"></div>`
@@ -85,7 +85,7 @@ jQuery文件上传插件，HTML5版uploadify，保持与uploadify一致的API，
 
 具体的API使用方式，可参考uploadify官网，完全是参照它的API来的。
 
-#####使用截图：
+##### 使用截图：
 ![使用截图](http://images.cnitblog.com/blog/520134/201312/01185252-55d3c4606ddb4a8995dc1b9563d2847b.jpg)
 
 >更多详细说明，欢迎访问我的博客:[http://www.cnblogs.com/lvdabao/p/3452858.html](http://www.cnblogs.com/lvdabao/p/3452858.html)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
